### PR TITLE
fix(security): handle expired JWT properly by throwing exception and …

### DIFF
--- a/src/main/java/com/ganesha/webshop/security/jwt/JwtUtils.java
+++ b/src/main/java/com/ganesha/webshop/security/jwt/JwtUtils.java
@@ -53,10 +53,13 @@ public class JwtUtils {
                     .build()
                     .parseSignedClaims(token);    // Csak parse, hibát dob, ha érvénytelen
             return true;
-        } catch (JwtException | IllegalArgumentException e) {
-            logger.error("JWT validation failed: {}", e.getMessage());
+        } catch (ExpiredJwtException e) {
+            logger.error("JWT token is expired: {}", e.getMessage());
+            throw e;
+        } catch (Exception e) {
+            logger.error("Invalid JWT token: {}", e.getMessage());
+            throw e;
         }
-        return false;
     }
 
     private SecretKey getSigningKey() {


### PR DESCRIPTION
…returning 401

- Updated validateJwtToken() to rethrow ExpiredJwtException instead of returning false silently
- Modified AuthTokenFilter to send 401 Unauthorized response when JWT is invalid or expired